### PR TITLE
Extend aggs

### DIFF
--- a/pyeqs/dsl/aggregations.py
+++ b/pyeqs/dsl/aggregations.py
@@ -14,7 +14,7 @@ class Aggregations(dict):
         self.metric = metric
         self.size = size
         self.min_doc_count = min_doc_count
-        self.order_type = order_type
+        self.order_type = self._pick_order_type(order_type, histogram_interval)
         self.order_dir = order_dir
         self.filter_val = filter_val
         self.filter_name = filter_name
@@ -31,7 +31,6 @@ class Aggregations(dict):
         else:
             self[self.agg_name] = {self.metric: {"field": self.field_name}}
             if self.metric == "terms":
-                self.order_type = self.order_type if self.order_type else "_count"
                 self[self.agg_name][self.metric].update({
                     "size": self.size,
                     "order": {self.order_type: self.order_dir},
@@ -49,7 +48,6 @@ class Aggregations(dict):
             }}
             self.pop(self.agg_name)
         if self.interval:
-            self.order_type = self.order_type if self.order_type else "_key"
             self[self.agg_name]["histogram"] = {
                 "field": self.field_name,
                 "interval": self.interval,
@@ -73,7 +71,6 @@ class Aggregations(dict):
                 }}
         }
         if self.metric == "terms":
-            self.order_type = self.order_type if self.order_type else "_count"
             nesting["aggregations"][self.agg_name][self.metric].update({
                 "size": self.size,
                 "order": {self.order_type: self.order_dir},
@@ -96,3 +93,11 @@ class Aggregations(dict):
             if i + 1 == len(self.range_list):
                 agg_ranges.append({"from": val})
         return agg_ranges
+
+    def _pick_order_type(self, order_type, hist):
+        if order_type:
+            return order_type
+        elif hist:
+            return "_key"
+        else:
+            return "_count"

--- a/pyeqs/dsl/aggregations.py
+++ b/pyeqs/dsl/aggregations.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals, absolute_import
 class Aggregations(dict):
 
     def __init__(self, agg_name, field_name, metric, size=0, min_doc_count=1,
-                 order_type="_count", order_dir="desc", filter_val=None, filter_name=None,
+                 order_type=None, order_dir="desc", filter_val=None, filter_name=None,
                  global_name=None, nested_path=None, range_list=None, range_name=None,
                  histogram_interval=None):
         super(Aggregations, self).__init__()
@@ -31,6 +31,7 @@ class Aggregations(dict):
         else:
             self[self.agg_name] = {self.metric: {"field": self.field_name}}
             if self.metric == "terms":
+                self.order_type = self.order_type if self.order_type else "_count"
                 self[self.agg_name][self.metric].update({
                     "size": self.size,
                     "order": {self.order_type: self.order_dir},
@@ -48,9 +49,12 @@ class Aggregations(dict):
             }}
             self.pop(self.agg_name)
         if self.interval:
+            self.order_type = self.order_type if self.order_type else "_key"
             self[self.agg_name]["histogram"] = {
                 "field": self.field_name,
-                "interval": self.interval
+                "interval": self.interval,
+                "order": {self.order_type: self.order_dir},
+                "min_doc_count": self.min_doc_count
             }
             self[self.agg_name].pop(self.metric)
         elif self.filter_val and self.filter_name:
@@ -69,6 +73,7 @@ class Aggregations(dict):
                 }}
         }
         if self.metric == "terms":
+            self.order_type = self.order_type if self.order_type else "_count"
             nesting["aggregations"][self.agg_name][self.metric].update({
                 "size": self.size,
                 "order": {self.order_type: self.order_dir},

--- a/pyeqs/dsl/aggregations.py
+++ b/pyeqs/dsl/aggregations.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals, absolute_import
 
 class Aggregations(dict):
 
-    def __init__(self, agg_name, field_name, metric, size=0, filter_val=None, filter_name=None,
+    def __init__(self, agg_name, field_name, metric, size=0, min_doc_count=1,
+                 order_type="_count", order_dir="desc", filter_val=None, filter_name=None,
                  global_name=None, nested_path=None, range_list=None, range_name=None,
                  histogram_interval=None):
         super(Aggregations, self).__init__()
@@ -12,6 +13,9 @@ class Aggregations(dict):
         self.field_name = field_name
         self.metric = metric
         self.size = size
+        self.min_doc_count = min_doc_count
+        self.order_type = order_type
+        self.order_dir = order_dir
         self.filter_val = filter_val
         self.filter_name = filter_name
         self.global_name = global_name
@@ -27,7 +31,11 @@ class Aggregations(dict):
         else:
             self[self.agg_name] = {self.metric: {"field": self.field_name}}
             if self.metric == "terms":
-                self[self.agg_name][self.metric].update({"size": self.size})
+                self[self.agg_name][self.metric].update({
+                    "size": self.size,
+                    "order": {self.order_type: self.order_dir},
+                    "min_doc_count": self.min_doc_count
+                })
 
         if self.range_list:
             if not self.range_name:
@@ -61,7 +69,11 @@ class Aggregations(dict):
                 }}
         }
         if self.metric == "terms":
-            nesting["aggregations"][self.agg_name][self.metric].update({"size": self.size})
+            nesting["aggregations"][self.agg_name][self.metric].update({
+                "size": self.size,
+                "order": {self.order_type: self.order_dir},
+                "min_doc_count": self.min_doc_count
+            })
         return nesting
 
     def _ranging(self):

--- a/tests/functional/test_aggregations.py
+++ b/tests/functional/test_aggregations.py
@@ -58,6 +58,154 @@ def test_search_aggregation_with_size(context):
 
 @requires_es_gte('1.1.0')
 @scenario(prepare_data, cleanup_data)
+def test_search_aggregation_with_order_one(context):
+    """
+    Search with aggregation ordered by count descending
+    """
+    # When create a queryset
+    t = QuerySet("localhost", index="foo")
+
+    # And there are records
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbar"})
+
+    # And I do an aggregated search
+    t.aggregate(aggregation=Aggregations("foo_attrs", "bar", "terms",
+                                         order_type="_count", order_dir="desc"))
+    t[0:10]
+
+    # Then I get a the expected results
+    t.aggregations().should.have.key('foo_attrs')
+
+    t.aggregations()['foo_attrs'].should.have.key("buckets").being.equal([
+        {u'key': u'baz', u'doc_count': 3},
+        {u'key': u'bazbaz', u'doc_count': 2},
+        {u'key': u'bazbar', u'doc_count': 1}])
+
+
+@scenario(prepare_data, cleanup_data)
+def test_search_aggregation_with_order_two(context):
+    """
+    Search with aggregation ordered by count ascending
+    """
+    # When create a queryset
+    t = QuerySet("localhost", index="foo")
+
+    # And there are records
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbar"})
+
+    # And I do an aggregated search
+    t.aggregate(aggregation=Aggregations("foo_attrs", "bar", "terms",
+                                         order_type="_count", order_dir="asc"))
+    t[0:10]
+
+    # Then I get a the expected results
+    t.aggregations().should.have.key('foo_attrs')
+
+    t.aggregations()['foo_attrs'].should.have.key("buckets").being.equal([
+        {u'key': u'bazbar', u'doc_count': 1},
+        {u'key': u'bazbaz', u'doc_count': 2},
+        {u'key': u'baz', u'doc_count': 3}])
+
+
+@scenario(prepare_data, cleanup_data)
+def test_search_aggregation_with_order_three(context):
+    """
+    Search with aggregation ordered by term descending
+    """
+    # When create a queryset
+    t = QuerySet("localhost", index="foo")
+
+    # And there are records
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbar"})
+
+    # And I do an aggregated search
+    t.aggregate(aggregation=Aggregations("foo_attrs", "bar", "terms",
+                                         order_type="_term", order_dir="desc"))
+    t[0:10]
+
+    # Then I get a the expected results
+    t.aggregations().should.have.key('foo_attrs')
+
+    t.aggregations()['foo_attrs'].should.have.key("buckets").being.equal([
+        {u'key': u'bazbaz', u'doc_count': 2},
+        {u'key': u'bazbar', u'doc_count': 1},
+        {u'key': u'baz', u'doc_count': 3}])
+
+
+@scenario(prepare_data, cleanup_data)
+def test_search_aggregation_with_order_four(context):
+    """
+    Search with aggregation ordered by term ascending
+    """
+    # When create a queryset
+    t = QuerySet("localhost", index="foo")
+
+    # And there are records
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbar"})
+
+    # And I do an aggregated search
+    t.aggregate(aggregation=Aggregations("foo_attrs", "bar", "terms",
+                                         order_type="_term", order_dir="asc"))
+    t[0:10]
+
+    # Then I get a the expected results
+    t.aggregations().should.have.key('foo_attrs')
+
+    t.aggregations()['foo_attrs'].should.have.key("buckets").being.equal([
+        {u'key': u'baz', u'doc_count': 3},
+        {u'key': u'bazbar', u'doc_count': 1},
+        {u'key': u'bazbaz', u'doc_count': 2}])
+
+
+@scenario(prepare_data, cleanup_data)
+def test_search_aggregation_with_min_doc_count(context):
+    """
+    Search with terms aggregation w/ a min_doc_count
+    """
+    # When create a queryset
+    t = QuerySet("localhost", index="foo")
+
+    # And there are records
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "baz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbaz"})
+    add_document("foo", {"bar": "bazbar"})
+
+    # And I do an aggregated search
+    t.aggregate(aggregation=Aggregations("foo_attrs", "bar", "terms", min_doc_count=2))
+    t[0:10]
+
+    # Then I get a the expected results
+    t.aggregations().should.have.key('foo_attrs')
+
+    t.aggregations()['foo_attrs'].should.have.key("buckets").being.equal([
+        {u'key': u'baz', u'doc_count': 3},
+        {u'key': u'bazbaz', u'doc_count': 2}])
+
+
+@scenario(prepare_data, cleanup_data)
 def test_search_multi_aggregations(context):
     """
     Search with multiple aggregations

--- a/tests/functional/test_aggregations.py
+++ b/tests/functional/test_aggregations.py
@@ -87,6 +87,7 @@ def test_search_terms_aggregation_with_order_one(context):
         {u'key': u'bazbar', u'doc_count': 1}])
 
 
+@requires_es_gte('1.1.0')
 @scenario(prepare_data, cleanup_data)
 def test_search_terms_aggregation_with_order_two(context):
     """
@@ -117,6 +118,7 @@ def test_search_terms_aggregation_with_order_two(context):
         {u'key': u'baz', u'doc_count': 3}])
 
 
+@requires_es_gte('1.1.0')
 @scenario(prepare_data, cleanup_data)
 def test_search_terms_aggregation_with_order_three(context):
     """
@@ -147,6 +149,7 @@ def test_search_terms_aggregation_with_order_three(context):
         {u'key': u'baz', u'doc_count': 3}])
 
 
+@requires_es_gte('1.1.0')
 @scenario(prepare_data, cleanup_data)
 def test_search_terms_aggregation_with_order_four(context):
     """
@@ -177,6 +180,7 @@ def test_search_terms_aggregation_with_order_four(context):
         {u'key': u'bazbaz', u'doc_count': 2}])
 
 
+@requires_es_gte('1.1.0')
 @scenario(prepare_data, cleanup_data)
 def test_search_terms_aggregation_with_min_doc_count(context):
     """
@@ -205,6 +209,7 @@ def test_search_terms_aggregation_with_min_doc_count(context):
         {u'key': u'bazbaz', u'doc_count': 2}])
 
 
+@requires_es_gte('1.1.0')
 @scenario(prepare_data, cleanup_data)
 def test_search_multi_aggregations(context):
     """
@@ -417,6 +422,7 @@ def test_search_histogram_aggregations(context):
         {u'key': 0, u'doc_count': 2}])
 
 
+@requires_es_gte('1.1.0')
 @scenario(prepare_data, cleanup_data)
 def test_search_histogram_aggregations_with_order(context):
     """
@@ -449,6 +455,7 @@ def test_search_histogram_aggregations_with_order(context):
         {u'key': 4, u'doc_count': 3}])
 
 
+@requires_es_gte('1.1.0')
 @scenario(prepare_data, cleanup_data)
 def test_search_histogram_aggregations_with_min_doc_count(context):
     """

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -287,7 +287,55 @@ def test_add_agg_histogram():
         "agg_name": {
             "histogram": {
                 "field": "field_name",
-                "interval": 20
+                "interval": 20,
+                "order": {"_key": "desc"},
+                "min_doc_count": 1
+            }
+        }
+    }
+
+    json.dumps(t).should.equal(json.dumps(results))
+
+
+def test_add_agg_histogram_with_order():
+    """
+    Create an aggregations block w/ histogram intervals and order type/direction
+    """
+    # Whan add an agg block w/ interval
+    t = Aggregations("agg_name", "field_name", "metric", histogram_interval=20,
+                     order_type="_count", order_dir="asc")
+
+    # Then I see correct json
+    results = {
+        "agg_name": {
+            "histogram": {
+                "field": "field_name",
+                "interval": 20,
+                "order": {"_count": "asc"},
+                "min_doc_count": 1
+            }
+        }
+    }
+
+    json.dumps(t).should.equal(json.dumps(results))
+
+
+def test_add_agg_histogram_with_min_doc_count():
+    """
+    Create an aggregations block w/ histogram intervals and min_doc_count
+    """
+    # Whan add an agg block w/ interval
+    t = Aggregations("agg_name", "field_name", "metric", histogram_interval=20,
+                     min_doc_count=10)
+
+    # Then I see correct json
+    results = {
+        "agg_name": {
+            "histogram": {
+                "field": "field_name",
+                "interval": 20,
+                "order": {"_key": "desc"},
+                "min_doc_count": 10
             }
         }
     }

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import json
-
 from pyeqs.dsl import Aggregations
+from tests.helpers import homogeneous
 
 
 def test_add_agg():
@@ -20,7 +19,7 @@ def test_add_agg():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_with_size():
@@ -42,7 +41,7 @@ def test_add_agg_with_size():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_with_order():
@@ -64,7 +63,7 @@ def test_add_agg_with_order():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_with_min_doc_count():
@@ -86,7 +85,7 @@ def test_add_agg_with_min_doc_count():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_nested():
@@ -106,7 +105,7 @@ def test_add_agg_nested():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_nested_with_size():
@@ -132,7 +131,7 @@ def test_add_agg_nested_with_size():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_nested_with_order():
@@ -158,7 +157,7 @@ def test_add_agg_nested_with_order():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_nested_with_min_doc_count():
@@ -184,7 +183,7 @@ def test_add_agg_nested_with_min_doc_count():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_filtered():
@@ -208,7 +207,7 @@ def test_add_agg_filtered():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_global():
@@ -228,7 +227,7 @@ def test_add_agg_global():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_range():
@@ -253,7 +252,7 @@ def test_add_agg_range():
             }}
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
     # Also works without a given range_name
     t = Aggregations("agg_name", "field_name", "metric", range_list=range_list)
@@ -272,7 +271,7 @@ def test_add_agg_range():
             }}
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_histogram():
@@ -294,7 +293,7 @@ def test_add_agg_histogram():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_histogram_with_order():
@@ -317,7 +316,7 @@ def test_add_agg_histogram_with_order():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)
 
 
 def test_add_agg_histogram_with_min_doc_count():
@@ -340,4 +339,4 @@ def test_add_agg_histogram_with_min_doc_count():
         }
     }
 
-    json.dumps(t).should.equal(json.dumps(results))
+    homogeneous(t, results)

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -33,7 +33,56 @@ def test_add_agg_with_size():
     # Then I see correct json
     results = {
         "agg_name": {
-            "terms": {"field": "field_name", "size": 1}
+            "terms": {
+                "field": "field_name",
+                "order": {"_count": "desc"},
+                "min_doc_count": 1,
+                "size": 1
+            }
+        }
+    }
+
+    json.dumps(t).should.equal(json.dumps(results))
+
+
+def test_add_agg_with_order():
+    """
+    Create aggregations block specifying order type and direction
+    """
+    # When add a terms agg block w/ size
+    t = Aggregations("agg_name", "field_name", "terms", order_type="_term", order_dir="asc")
+
+    # Then I see correct json
+    results = {
+        "agg_name": {
+            "terms": {
+                "field": "field_name",
+                "order": {"_term": "asc"},
+                "min_doc_count": 1,
+                "size": 0
+            }
+        }
+    }
+
+    json.dumps(t).should.equal(json.dumps(results))
+
+
+def test_add_agg_with_min_doc_count():
+    """
+    Create aggregations block specifying the min_doc_count
+    """
+    # When add a terms agg block w/ size
+    t = Aggregations("agg_name", "field_name", "terms", min_doc_count=10)
+
+    # Then I see correct json
+    results = {
+        "agg_name": {
+            "terms": {
+                "field": "field_name",
+                "order": {"_count": "desc"},
+                "min_doc_count": 10,
+                "size": 0
+            }
         }
     }
 
@@ -75,7 +124,61 @@ def test_add_agg_nested_with_size():
             "aggregations": {
                 "agg_name": {"terms": {
                     "field": "nested_doc.field_name",
+                    "order": {"_count": "desc"},
+                    "min_doc_count": 1,
                     "size": 1
+                }}
+            }
+        }
+    }
+
+    json.dumps(t).should.equal(json.dumps(results))
+
+
+def test_add_agg_nested_with_order():
+    """
+    Create nested aggregations block specifying order type and direction
+    """
+    # When add a nested_path with terms agg block w/ size
+    t = Aggregations("agg_name", "field_name", "terms", order_type="_term", order_dir="asc",
+                     nested_path="nested_doc")
+
+    # The I see correct json
+    results = {
+        "nested_doc": {
+            "nested": {"path": "nested_doc"},
+            "aggregations": {
+                "agg_name": {"terms": {
+                    "field": "nested_doc.field_name",
+                    "order": {"_term": "asc"},
+                    "min_doc_count": 1,
+                    "size": 0
+                }}
+            }
+        }
+    }
+
+    json.dumps(t).should.equal(json.dumps(results))
+
+
+def test_add_agg_nested_with_min_doc_count():
+    """
+    Create nested aggregations block specifying min_doc_count
+    """
+    # When add a nested_path with terms agg block w/ size
+    t = Aggregations("agg_name", "field_name", "terms", min_doc_count=10,
+                     nested_path="nested_doc")
+
+    # The I see correct json
+    results = {
+        "nested_doc": {
+            "nested": {"path": "nested_doc"},
+            "aggregations": {
+                "agg_name": {"terms": {
+                    "field": "nested_doc.field_name",
+                    "order": {"_count": "desc"},
+                    "min_doc_count": 10,
+                    "size": 0
                 }}
             }
         }

--- a/tests/unit/test_queryset.py
+++ b/tests/unit/test_queryset.py
@@ -567,6 +567,8 @@ def test_create_queryset_with_aggregation():
             "agg_name": {"metric": {"field": "field_name"}},
             "other_agg_name": {"terms": {
                 "field": "other_field_name",
+                "order": {"_count": "desc"},
+                "min_doc_count": 1,
                 "size": 1
             }}
         }


### PR DESCRIPTION
default values used for instantiating the params. since there are orders and min_doc_counts for both terms and histograms (but they have different default types) i accounted for that with `#_pick_order_type`

please double check @andrewgross 
