### PR TITLE
docs: fix simple typo, locaiton -> location

### DIFF
--- a/tests/functional/test_sorting.py
+++ b/tests/functional/test_sorting.py
@@ -138,7 +138,7 @@ def test_search_with_location_sort(context):
     # When create a query block
     t = QuerySet("localhost", index="foo")
 
-    # And there are locaiton records
+    # And there are location records
     add_document("foo", {"baz": 1, "location": {"lat": 40.0, "lon": 70.0}})
     add_document("foo", {"baz": 2, "location": {"lat": 40.0, "lon": 75.0}})
 


### PR DESCRIPTION
There is a small typo in tests/functional/test_sorting.py.

Should read `location` rather than `locaiton`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md